### PR TITLE
annotate column type explicitly for the geometry column type, otherwse fails in the EF > 2.2

### DIFF
--- a/EfCoreScaffoldMssql/Classes/ColumnViewModel.cs
+++ b/EfCoreScaffoldMssql/Classes/ColumnViewModel.cs
@@ -35,6 +35,7 @@ namespace EfCoreScaffoldMssql.Classes
                     case "datetime":
                     case "datetime2":
                     case "smalldatetime":
+                    case "geometry":
                         return true;
                 }
 


### PR DESCRIPTION
annotate column type explicitly for the geometry column type, otherwse fails in the EF > 2.2